### PR TITLE
Fix timer pause resets

### DIFF
--- a/src/components/SmartPomodoro.tsx
+++ b/src/components/SmartPomodoro.tsx
@@ -31,6 +31,7 @@ const SmartPomodoro = () => {
   const [showSessionComplete, setShowSessionComplete] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
+  const [sessionStarted, setSessionStarted] = useState(false);
 
   const { 
     timeLeft, 
@@ -41,6 +42,8 @@ const SmartPomodoro = () => {
     stopTimer,
     progress 
   } = useTimer(focusLength * 60, breakLength * 60);
+
+  const isPaused = sessionStarted && !isRunning && timeLeft > 0;
 
   const {
     tasks,
@@ -72,9 +75,17 @@ const SmartPomodoro = () => {
     setShowIntentDialog(true);
   };
 
+  const handleResume = () => {
+    startTimer();
+    if (shieldEnabled) {
+      setShowShield(true);
+    }
+  };
+
   const handleQuickStart = (task: string) => {
     setIntent(task);
     startTimer();
+    setSessionStarted(true);
     if (shieldEnabled) {
       setShowShield(true);
     }
@@ -89,6 +100,7 @@ const SmartPomodoro = () => {
   const handleIntentSubmit = () => {
     setShowIntentDialog(false);
     startTimer();
+    setSessionStarted(true);
     if (shieldEnabled) {
       setShowShield(true);
     }
@@ -100,9 +112,16 @@ const SmartPomodoro = () => {
     });
   };
 
+  const handleStop = () => {
+    stopTimer();
+    setShowShield(false);
+    setSessionStarted(false);
+  };
+
   const handleSessionComplete = () => {
     setShowShield(false);
     setShowSessionComplete(true);
+    setSessionStarted(false);
     
     // Only award XP if the session was at least 1 minute long
     if (focusLength >= 1) {
@@ -187,13 +206,15 @@ const SmartPomodoro = () => {
             timeLeft={timeLeft}
             progress={progress}
             isRunning={isRunning}
+            isPaused={isPaused}
             isBreak={isBreak}
             focusLength={focusLength}
             breakLength={breakLength}
             shieldEnabled={shieldEnabled}
             onStart={handleStart}
+            onResume={handleResume}
             onPause={pauseTimer}
-            onStop={stopTimer}
+            onStop={handleStop}
             onQuickStart={handleQuickStart}
             onFocusLengthChange={handleFocusLengthChange}
             onBreakLengthChange={handleBreakLengthChange}

--- a/src/components/TimerControls.tsx
+++ b/src/components/TimerControls.tsx
@@ -6,7 +6,9 @@ import { QuickStartDialog } from './QuickStartDialog';
 
 interface TimerControlsProps {
   isRunning: boolean;
+  isPaused: boolean;
   onStart: () => void;
+  onResume: () => void;
   onPause: () => void;
   onStop: () => void;
   onQuickStart: (task: string) => void;
@@ -14,7 +16,9 @@ interface TimerControlsProps {
 
 export const TimerControls: React.FC<TimerControlsProps> = ({
   isRunning,
+  isPaused,
   onStart,
+  onResume,
   onPause,
   onStop,
   onQuickStart
@@ -22,9 +26,13 @@ export const TimerControls: React.FC<TimerControlsProps> = ({
   return (
     <div className="flex justify-center space-x-4">
       {!isRunning ? (
-        <Button onClick={onStart} size="lg" className="bg-primary hover:bg-primary/90">
+        <Button
+          onClick={isPaused ? onResume : onStart}
+          size="lg"
+          className="bg-primary hover:bg-primary/90"
+        >
           <Play className="h-5 w-5 mr-2" />
-          Start Focus
+          {isPaused ? 'Resume' : 'Start Focus'}
         </Button>
       ) : (
         <>

--- a/src/components/TimerSection.tsx
+++ b/src/components/TimerSection.tsx
@@ -9,11 +9,13 @@ interface TimerSectionProps {
   timeLeft: number;
   progress: number;
   isRunning: boolean;
+  isPaused: boolean;
   isBreak: boolean;
   focusLength: number;
   breakLength: number;
   shieldEnabled: boolean;
   onStart: () => void;
+  onResume: () => void;
   onPause: () => void;
   onStop: () => void;
   onQuickStart: (task: string) => void;
@@ -26,11 +28,13 @@ export const TimerSection: React.FC<TimerSectionProps> = ({
   timeLeft,
   progress,
   isRunning,
+  isPaused,
   isBreak,
   focusLength,
   breakLength,
   shieldEnabled,
   onStart,
+  onResume,
   onPause,
   onStop,
   onQuickStart,
@@ -58,7 +62,9 @@ export const TimerSection: React.FC<TimerSectionProps> = ({
 
         <TimerControls
           isRunning={isRunning}
+          isPaused={isPaused}
           onStart={onStart}
+          onResume={onResume}
           onPause={onPause}
           onStop={onStop}
           onQuickStart={onQuickStart}

--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -71,13 +71,18 @@ export const useTimer = (focusDuration: number, breakDuration: number) => {
   }, [isRunning, timeLeft]);
 
   // Update timer when focus/break duration changes (only if not running)
+  // When pausing the timer we don't want to reset the remaining time, so
+  // exclude `isRunning` from the dependency list. This ensures the timer
+  // updates only when the durations themselves change while the timer is not
+  // actively counting down.
   useEffect(() => {
     if (!isRunning) {
       const newDuration = isBreak ? breakDuration : focusDuration;
       setTimeLeft(newDuration);
       setSessionDuration(newDuration);
     }
-  }, [focusDuration, breakDuration, isBreak, isRunning]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusDuration, breakDuration, isBreak]);
 
   return {
     timeLeft,


### PR DESCRIPTION
## Summary
- prevent timer from resetting when paused by removing `isRunning` from deps
- allow paused timers to resume without intention prompt
- display a Resume button when the timer is paused

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type etc.)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6841380694dc83228019ae8c5a47b576