### PR TITLE
Set dark mode default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/SmartPomodoro.tsx
+++ b/src/components/SmartPomodoro.tsx
@@ -30,7 +30,7 @@ const SmartPomodoro = () => {
   const [showShield, setShowShield] = useState(false);
   const [showSessionComplete, setShowSessionComplete] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(true);
   const [sessionStarted, setSessionStarted] = useState(false);
 
   const { 


### PR DESCRIPTION
## Summary
- default UI theme is dark on page load
- make the toggle allow switching back to light mode

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-empty-object-type`)*

------
https://chatgpt.com/codex/tasks/task_e_6841f8cee2648322a3d13ba13c2bc7d2