### PR TITLE
Reposition DistractionLog below timer

### DIFF
--- a/src/components/DistractionLog.tsx
+++ b/src/components/DistractionLog.tsx
@@ -28,7 +28,9 @@ export const DistractionLog: React.FC<DistractionLogProps> = ({ visible }) => {
   if (!visible) return null;
 
   return (
-    <Card className="p-4 bg-orange-50 dark:bg-orange-950/20 border-orange-200 dark:border-orange-800">
+    <Card
+      className="p-4 bg-orange-50 dark:bg-orange-950/20 border-orange-200 dark:border-orange-800 animate-in fade-in slide-in-from-top-2 duration-300"
+    >
       <div className="flex items-center gap-2 mb-3">
         <h3 className="font-medium text-orange-900 dark:text-orange-100">
           Distraction Log

--- a/src/components/SmartPomodoro.tsx
+++ b/src/components/SmartPomodoro.tsx
@@ -205,9 +205,6 @@ const SmartPomodoro = () => {
           </div>
         </header>
 
-        {/* Distraction Log - only show when timer is running */}
-        <DistractionLog visible={isRunning && !isBreak} />
-
         {/* Main Content */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-6">
           {/* Timer Card */}
@@ -256,6 +253,11 @@ const SmartPomodoro = () => {
               </TabsContent>
             </Tabs>
           </Card>
+        </div>
+
+        {/* Distraction Log - only show when timer is running */}
+        <div className="my-8 w-full lg:w-1/2 mx-auto">
+          <DistractionLog visible={isRunning && !isBreak} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- move `DistractionLog` below timer and tasks with matching width
- add fade+slide animation for smoother appearance

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842886c365083229545fc168c3b8229