### PR TITLE
Improve PWA caching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A modern, feature-rich Pomodoro timer designed to combat procrastination with pr
 - **Session Integration**: Link tasks and habits to focus sessions
 
 ### PWA & Performance
-- **Offline First**: Works completely offline with service worker caching
+- **Offline First**: Works offline using a network-first service worker that refreshes cached files automatically
 - **Installable**: Add to home screen on mobile/desktop
 - **Fast Loading**: Optimized for 90+ Lighthouse Performance score
 - **Local Storage**: All data persists locally using browser storage
@@ -125,7 +125,7 @@ npm run preview
 - **100% Local**: No data leaves your device
 - **No Analytics**: No tracking or telemetry
 - **No Accounts**: No sign-up required
-- **Offline First**: Works without internet connection
+- **Offline First**: Works without internet using up-to-date cached assets
 
 ## 📈 Performance Targets
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,53 +1,60 @@
+const CACHE_NAME = 'smart-pomodoro-v1.1.0';
+const OFFLINE_URL = '/offline.html';
 
-const CACHE_NAME = 'smart-pomodoro-v1.0.0';
-const urlsToCache = [
-  '/',
-  '/index.html',
-  '/src/main.tsx',
-  '/src/index.css',
-  '/manifest.json',
-  '/offline.html'
-];
-
-self.addEventListener('install', (event) => {
+self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then((cache) => {
-        console.log('Opened cache');
-        return cache.addAll(urlsToCache);
-      })
+    caches.open(CACHE_NAME).then(cache => cache.addAll([OFFLINE_URL]))
   );
 });
 
-self.addEventListener('fetch', (event) => {
-  event.respondWith(
-    caches.match(event.request)
-      .then((response) => {
-        // Return cached version or fetch from network
-        if (response) {
-          return response;
-        }
-        return fetch(event.request).catch(() => {
-          // Show offline page for navigation requests when offline
-          if (event.request.destination === 'document') {
-            return caches.match('/offline.html');
-          }
-        });
-      })
-  );
-});
-
-self.addEventListener('activate', (event) => {
+self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME) {
-            console.log('Deleting old cache:', cacheName);
-            return caches.delete(cacheName);
+    caches.keys().then(cacheNames =>
+      Promise.all(
+        cacheNames.map(name => {
+          if (name !== CACHE_NAME) {
+            return caches.delete(name);
           }
         })
-      );
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          return response;
+        })
+        .catch(async () => {
+          const cached = await caches.match(event.request);
+          return cached || caches.match(OFFLINE_URL);
+        })
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.open(CACHE_NAME).then(async cache => {
+      const cached = await cache.match(event.request);
+      const networkFetch = fetch(event.request)
+        .then(response => {
+          if (response && response.status === 200) {
+            cache.put(event.request, response.clone());
+          }
+          return response;
+        })
+        .catch(() => cached);
+      return cached || networkFetch;
     })
   );
 });


### PR DESCRIPTION
## Summary
- update README to document network-first service worker
- implement new service worker with network-first caching strategy and stale-while-revalidate

## Testing
- `npm run build`
- `npm run lint` *(fails: `@typescript-eslint/no-empty-object-type`)*

------
https://chatgpt.com/codex/tasks/task_e_6841faeabb048322b1213faad94b8301