### PR TITLE
Refactor timer as DualTimer component

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A modern, feature-rich Pomodoro timer designed to combat procrastination with pr
 
 ### Core Timer
 - **Customizable Focus/Break Periods**: Adjust focus (1-60 min) and break (1-30 min) durations
+- **Pomodoro Mode**: Automatically cycle focus and break sessions for a set total time
 - **Visual Countdown**: Beautiful circular progress indicator with smooth animations
 - **Audio & Vibration**: Session completion notifications (where supported)
 - **Responsive Design**: Works perfectly on desktop, tablet, and mobile

--- a/src/components/DualTimer.tsx
+++ b/src/components/DualTimer.tsx
@@ -1,0 +1,272 @@
+import React, { useState, useEffect } from 'react';
+import { Card } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+
+import { TimerDisplay } from './TimerDisplay';
+
+interface Segment {
+  type: 'focus' | 'break' | 'longBreak';
+  duration: number; // in minutes
+}
+
+function computeSchedule(
+  total: number,
+  focusLen: number,
+  shortBreak: number,
+  longBreak: number,
+  interval: number
+): Segment[] {
+  const schedule: Segment[] = [];
+  let minutes = total;
+  let cycle = 0;
+  let timeElapsed = 0;
+  let nextLongMark = 120;
+
+  while (minutes >= focusLen) {
+    schedule.push({ type: 'focus', duration: focusLen });
+    minutes -= focusLen;
+    timeElapsed += focusLen;
+    cycle++;
+
+    if (minutes <= 0) break;
+
+    let breakLen = shortBreak;
+    if (cycle % interval === 0) breakLen = longBreak;
+    if (timeElapsed >= nextLongMark) {
+      breakLen = longBreak;
+      nextLongMark += 120;
+    }
+
+    if (minutes < breakLen) break;
+    schedule.push({ type: breakLen === longBreak ? 'longBreak' : 'break', duration: breakLen });
+    minutes -= breakLen;
+    timeElapsed += breakLen;
+  }
+
+  if (minutes >= focusLen / 2) {
+    schedule.push({ type: 'focus', duration: minutes });
+  }
+  return schedule;
+}
+
+function describeSchedule(schedule: Segment[], focusLen: number, shortBreak: number, longBreak: number) {
+  let focusCount = 0;
+  let breakCount = 0;
+  let longBreakCount = 0;
+  schedule.forEach((s) => {
+    if (s.type === 'focus') focusCount++;
+    else if (s.type === 'break') breakCount++;
+    else longBreakCount++;
+  });
+  const parts = [`You'll work ${focusCount} × ${focusLen} min`];
+  if (breakCount > 0) parts.push(`${breakCount} × ${shortBreak} min breaks`);
+  if (longBreakCount > 0) parts.push(`${longBreakCount} × ${longBreak} min long breaks`);
+  if (schedule.length && schedule[schedule.length - 1].duration !== focusLen) {
+    const extra = schedule[schedule.length - 1];
+    if (extra.type === 'focus' && extra.duration !== focusLen) {
+      parts.push(`final focus ${extra.duration} min`);
+    }
+  }
+  return parts.join(' with ') + '.';
+}
+
+export const DualTimer: React.FC = () => {
+  const [mode, setMode] = useState<'regular' | 'pomodoro'>('regular');
+  const [regularMinutes, setRegularMinutes] = useState(25);
+  const [totalMinutes, setTotalMinutes] = useState(60);
+
+  const [method, setMethod] = useState<'classic' | '50' | '60' | 'custom'>('classic');
+  const [focusLen, setFocusLen] = useState(25);
+  const [shortBreak, setShortBreak] = useState(5);
+  const [longBreak, setLongBreak] = useState(15);
+  const [interval, setIntervalCount] = useState(4);
+
+  const [longChoice, setLongChoice] = useState<'15' | '30' | 'custom'>('15');
+  const [customLong, setCustomLong] = useState(15);
+  const [showSettings, setShowSettings] = useState(false);
+
+  const effectiveLongBreak = longChoice === 'custom' ? customLong : parseInt(longChoice, 10);
+
+  useEffect(() => {
+    if (method === 'classic') {
+      setFocusLen(25);
+      setShortBreak(5);
+      setLongBreak(15);
+      setIntervalCount(4);
+    } else if (method === '50') {
+      setFocusLen(50);
+      setShortBreak(10);
+      setLongBreak(15);
+      setIntervalCount(3);
+    } else if (method === '60') {
+      setFocusLen(60);
+      setShortBreak(15);
+      setLongBreak(20);
+      setIntervalCount(2);
+    }
+  }, [method]);
+
+  const schedule = mode === 'pomodoro'
+    ? computeSchedule(totalMinutes, focusLen, shortBreak, effectiveLongBreak, interval)
+    : [{ type: 'focus', duration: regularMinutes }];
+
+  const [index, setIndex] = useState(0);
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  const [running, setRunning] = useState(false);
+  const [paused, setPaused] = useState(false);
+
+  useEffect(() => {
+    if (!running) return;
+    const id = window.setInterval(() => {
+      setSecondsLeft((s) => {
+        if (s <= 1) {
+          clearInterval(id);
+          handleSegmentEnd();
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [running, handleSegmentEnd]);
+
+  const start = () => {
+    if (!schedule.length) return;
+    setIndex(0);
+    setSecondsLeft(schedule[0].duration * 60);
+    setRunning(true);
+    setPaused(false);
+  };
+  const pause = () => {
+    setRunning(false);
+    setPaused(true);
+  };
+  const resume = () => {
+    setRunning(true);
+    setPaused(false);
+  };
+  const stop = () => {
+    setRunning(false);
+    setPaused(false);
+    setIndex(0);
+    setSecondsLeft(0);
+  };
+
+  const handleSegmentEnd = () => {
+    if (index + 1 < schedule.length) {
+      const next = index + 1;
+      setIndex(next);
+      setSecondsLeft(schedule[next].duration * 60);
+      setRunning(true);
+    } else {
+      setRunning(false);
+    }
+  };
+
+  const preview = describeSchedule(schedule, focusLen, shortBreak, effectiveLongBreak);
+
+  return (
+    <Card className="p-6 space-y-6">
+      <div className="flex items-center space-x-2 justify-center">
+        <Label htmlFor="mode">Auto Pomodoro</Label>
+        <Switch id="mode" checked={mode === 'pomodoro'} onCheckedChange={c => setMode(c ? 'pomodoro' : 'regular')} />
+      </div>
+
+      {mode === 'regular' ? (
+        <div className="flex items-center justify-center space-x-2">
+          <Label htmlFor="regular" className="text-foreground">Minutes</Label>
+          <Input id="regular" type="number" className="w-24" value={regularMinutes} onChange={e => setRegularMinutes(Number(e.target.value))} />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex items-center justify-center space-x-2">
+            <Label htmlFor="total" className="text-foreground">Total focus window, min</Label>
+            <Input id="total" type="number" className="w-24" value={totalMinutes} onChange={e => setTotalMinutes(Number(e.target.value))} />
+          </div>
+          <Button variant="outline" onClick={() => setShowSettings(s => !s)}>Customize Pomodoro Settings</Button>
+          {showSettings && (
+            <div className="space-y-4">
+              <div className="flex items-center space-x-2">
+                <Label htmlFor="method">Method</Label>
+                <Select value={method} onValueChange={v => setMethod(v as 'classic' | '50' | '60' | 'custom')}>
+                  <SelectTrigger id="method" className="w-40">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="classic">Classic 25/5</SelectItem>
+                    <SelectItem value="50">50/10</SelectItem>
+                    <SelectItem value="60">60/15</SelectItem>
+                    <SelectItem value="custom">Custom</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              {method === 'custom' && (
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="flex items-center space-x-2">
+                    <Label htmlFor="focus">Focus</Label>
+                    <Input id="focus" type="number" className="w-16" value={focusLen} onChange={e => setFocusLen(Number(e.target.value))} />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Label htmlFor="break">Break</Label>
+                    <Input id="break" type="number" className="w-16" value={shortBreak} onChange={e => setShortBreak(Number(e.target.value))} />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Label htmlFor="long">Long Break</Label>
+                    <Input id="long" type="number" className="w-16" value={longBreak} onChange={e => setLongBreak(Number(e.target.value))} />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Label htmlFor="interval">Blocks before long break</Label>
+                    <Input id="interval" type="number" className="w-16" value={interval} onChange={e => setIntervalCount(Number(e.target.value))} />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+          {totalMinutes > 120 && (
+            <div className="space-y-2">
+              <p className="text-sm text-center">Studies show that after 2 hours your effectiveness degrades - choose your long breaks duration.</p>
+              <ToggleGroup type="single" value={longChoice} onValueChange={v => v && setLongChoice(v as '15' | '30' | 'custom')} className="flex justify-center">
+                <ToggleGroupItem value="15">15 min</ToggleGroupItem>
+                <ToggleGroupItem value="30">30 min</ToggleGroupItem>
+                <ToggleGroupItem value="custom" className="px-2">
+                  <Input type="number" className="w-12" value={customLong} onChange={e => setCustomLong(Number(e.target.value))} />
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+          )}
+        </div>
+      )}
+
+      <Alert>
+        <AlertDescription>{preview}</AlertDescription>
+      </Alert>
+
+      <TimerDisplay timeLeft={secondsLeft} progress={schedule.length ? (schedule[index].duration * 60 - secondsLeft) / (schedule[index].duration * 60) : 0} isBreak={schedule[index]?.type !== 'focus'} isPaused={paused} />
+
+      <div className="flex justify-center space-x-4">
+        {!running ? (
+          <Button onClick={paused ? resume : start} className="bg-primary hover:bg-primary/90">
+            {paused ? 'Resume' : 'Start'}
+          </Button>
+        ) : (
+          <>
+            <Button onClick={pause} variant="outline">Pause</Button>
+            <Button onClick={stop} variant="destructive">Stop</Button>
+          </>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/src/components/SmartPomodoro.tsx
+++ b/src/components/SmartPomodoro.tsx
@@ -19,11 +19,14 @@ import { Confetti } from './Confetti';
 import { XPTooltip } from './XPTooltip';
 import { DistractionLog } from './DistractionLog';
 import { Footer } from './Footer';
-import { TimerSection } from './TimerSection';
+import { DualTimer } from './DualTimer';
 
 const SmartPomodoro = () => {
   const [focusLength, setFocusLength] = useState(25);
   const [breakLength, setBreakLength] = useState(5);
+  const [totalDuration, setTotalDuration] = useState(60);
+  const [mode, setMode] = useState<'regular' | 'pomodoro'>('regular');
+  const [currentCycle, setCurrentCycle] = useState(1);
   const [showIntentDialog, setShowIntentDialog] = useState(false);
   const [intent, setIntent] = useState('');
   const [shieldEnabled, setShieldEnabled] = useState(false);
@@ -37,13 +40,18 @@ const SmartPomodoro = () => {
     timeLeft, 
     isRunning, 
     isBreak, 
-    startTimer, 
-    pauseTimer, 
+    startTimer,
+    pauseTimer,
     stopTimer,
-    progress 
+    switchToBreak,
+    switchToFocus,
+    progress
   } = useTimer(focusLength * 60, breakLength * 60);
 
   const isPaused = sessionStarted && !isRunning && timeLeft > 0;
+
+  const cycles = Math.max(1, Math.floor(totalDuration / focusLength));
+  const breakCount = Math.max(0, cycles - 1);
 
   const {
     tasks,
@@ -93,6 +101,8 @@ const SmartPomodoro = () => {
 
   const handleQuickStart = (task: string) => {
     setIntent(task);
+    switchToFocus();
+    setCurrentCycle(1);
     startTimer();
     setSessionStarted(true);
     if (shieldEnabled) {
@@ -108,6 +118,8 @@ const SmartPomodoro = () => {
 
   const handleIntentSubmit = () => {
     setShowIntentDialog(false);
+    switchToFocus();
+    setCurrentCycle(1);
     startTimer();
     setSessionStarted(true);
     if (shieldEnabled) {
@@ -123,8 +135,10 @@ const SmartPomodoro = () => {
 
   const handleStop = () => {
     stopTimer();
+    switchToFocus();
     setShowShield(false);
     setSessionStarted(false);
+    setCurrentCycle(1);
   };
 
   const handleSessionComplete = () => {
@@ -148,10 +162,26 @@ const SmartPomodoro = () => {
   };
 
   useEffect(() => {
-    if (!isRunning && timeLeft === 0 && !isBreak) {
-      handleSessionComplete();
+    if (isRunning || timeLeft !== 0) return;
+
+    if (mode !== 'pomodoro') {
+      if (!isBreak) handleSessionComplete();
+      return;
     }
-  }, [isRunning, timeLeft, isBreak]);
+
+    const sessionComplete = () => handleSessionComplete();
+
+    if (isBreak) {
+      if (currentCycle >= cycles) return sessionComplete();
+      switchToFocus();
+    } else {
+      if (currentCycle >= cycles) return sessionComplete();
+      setCurrentCycle((c) => c + 1);
+      switchToBreak();
+    }
+
+    startTimer();
+  }, [isRunning, timeLeft, isBreak, mode, cycles, currentCycle]);
 
   // Validation functions for timer inputs
   const handleFocusLengthChange = (value: number) => {
@@ -162,6 +192,17 @@ const SmartPomodoro = () => {
   const handleBreakLengthChange = (value: number) => {
     const validValue = Math.max(1, Math.min(30, value)); // Min 1, Max 30
     setBreakLength(validValue);
+  };
+
+  const handleTotalDurationChange = (value: number) => {
+    const validValue = Math.max(1, value);
+    setTotalDuration(validValue);
+  };
+
+  const handleModeChange = (val: 'regular' | 'pomodoro') => {
+    setMode(val);
+    setCurrentCycle(1);
+    switchToFocus();
   };
 
   return (
@@ -217,24 +258,7 @@ const SmartPomodoro = () => {
         {/* Main Content */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-6">
           {/* Timer Card */}
-          <TimerSection
-            timeLeft={timeLeft}
-            progress={progress}
-            isRunning={isRunning}
-            isPaused={isPaused}
-            isBreak={isBreak}
-            focusLength={focusLength}
-            breakLength={breakLength}
-            shieldEnabled={shieldEnabled}
-            onStart={handleStart}
-            onResume={handleResume}
-            onPause={pauseTimer}
-            onStop={handleStop}
-            onQuickStart={handleQuickStart}
-            onFocusLengthChange={handleFocusLengthChange}
-            onBreakLengthChange={handleBreakLengthChange}
-            onShieldToggle={setShieldEnabled}
-          />
+          <DualTimer />
 
           {/* Tasks and Habits */}
           <Card className="p-6">

--- a/src/components/TimerSection.tsx
+++ b/src/components/TimerSection.tsx
@@ -10,16 +10,21 @@ interface TimerSectionProps {
   isRunning: boolean;
   isPaused: boolean;
   isBreak: boolean;
+  mode: 'regular' | 'pomodoro';
   focusLength: number;
   breakLength: number;
+  totalDuration: number;
+  breakCount: number;
   shieldEnabled: boolean;
   onStart: () => void;
   onResume: () => void;
   onPause: () => void;
   onStop: () => void;
   onQuickStart: (task: string) => void;
+  onModeChange: (mode: 'regular' | 'pomodoro') => void;
   onFocusLengthChange: (value: number) => void;
   onBreakLengthChange: (value: number) => void;
+  onTotalDurationChange: (value: number) => void;
   onShieldToggle: (enabled: boolean) => void;
 }
 
@@ -29,27 +34,37 @@ export const TimerSection: React.FC<TimerSectionProps> = ({
   isRunning,
   isPaused,
   isBreak,
+  mode,
   focusLength,
   breakLength,
+  totalDuration,
+  breakCount,
   shieldEnabled,
   onStart,
   onResume,
   onPause,
   onStop,
   onQuickStart,
+  onModeChange,
   onFocusLengthChange,
   onBreakLengthChange,
+  onTotalDurationChange,
   onShieldToggle
 }) => {
   return (
     <Card className="p-6">
       <div className="text-center space-y-6">
         <TimerSettings
+          mode={mode}
           focusLength={focusLength}
           breakLength={breakLength}
+          totalDuration={totalDuration}
+          breakCount={breakCount}
           shieldEnabled={shieldEnabled}
+          onModeChange={onModeChange}
           onFocusLengthChange={onFocusLengthChange}
           onBreakLengthChange={onBreakLengthChange}
+          onTotalDurationChange={onTotalDurationChange}
           onShieldToggle={onShieldToggle}
         />
 

--- a/src/components/TimerSettings.tsx
+++ b/src/components/TimerSettings.tsx
@@ -4,26 +4,56 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Shield } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
 
 interface TimerSettingsProps {
+  mode: 'regular' | 'pomodoro';
   focusLength: number;
   breakLength: number;
+  totalDuration: number;
+  breakCount: number;
   shieldEnabled: boolean;
+  onModeChange: (mode: 'regular' | 'pomodoro') => void;
   onFocusLengthChange: (value: number) => void;
   onBreakLengthChange: (value: number) => void;
+  onTotalDurationChange: (value: number) => void;
   onShieldToggle: (enabled: boolean) => void;
 }
 
 export const TimerSettings: React.FC<TimerSettingsProps> = ({
+  mode,
   focusLength,
   breakLength,
+  totalDuration,
+  breakCount,
   shieldEnabled,
+  onModeChange,
   onFocusLengthChange,
   onBreakLengthChange,
+  onTotalDurationChange,
   onShieldToggle
 }) => {
   return (
     <div className="space-y-4">
+      <div className="flex items-center justify-center space-x-2">
+        <Label htmlFor="mode" className="text-foreground">Mode</Label>
+        <Select value={mode} onValueChange={(val) => onModeChange(val as 'regular' | 'pomodoro')}>
+          <SelectTrigger id="mode" className="w-32">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="regular">Regular</SelectItem>
+            <SelectItem value="pomodoro">Pomodoro</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
       <div className="flex justify-center space-x-4">
         <div className="flex items-center space-x-2">
           <Label htmlFor="focus-length" className="text-foreground">Focus</Label>
@@ -51,7 +81,25 @@ export const TimerSettings: React.FC<TimerSettingsProps> = ({
           />
           <span className="text-sm text-muted-foreground">min</span>
         </div>
+        {mode === 'pomodoro' && (
+          <div className="flex items-center space-x-2">
+            <Label htmlFor="total-duration" className="text-foreground">Total</Label>
+            <Input
+              id="total-duration"
+              type="number"
+              value={totalDuration}
+              onChange={(e) => onTotalDurationChange(Number(e.target.value))}
+              className="w-20"
+              min="1"
+            />
+            <span className="text-sm text-muted-foreground">min</span>
+          </div>
+        )}
       </div>
+
+      {mode === 'pomodoro' && (
+        <p className="text-sm text-muted-foreground text-center">Breaks: {breakCount}</p>
+      )}
 
       <div className="flex items-center justify-center space-x-2">
         <Switch
@@ -64,7 +112,7 @@ export const TimerSettings: React.FC<TimerSettingsProps> = ({
           <span>Distraction Shield</span>
         </Label>
       </div>
-      
+
       {shieldEnabled && (
         <p className="text-xs text-muted-foreground text-center">
           Shield will overlay the screen during focus sessions (works best in full browser)


### PR DESCRIPTION
## Summary
- add new `DualTimer` component implementing regular and auto Pomodoro modes
- show schedule preview and customizable method options
- integrate `DualTimer` into `SmartPomodoro`

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6844c24fe5d48322a8a15f10bab0bd12