### PR TITLE
Add distraction log to focus overlay

### DIFF
--- a/src/components/DistractionShield.tsx
+++ b/src/components/DistractionShield.tsx
@@ -62,7 +62,7 @@ export const DistractionShield: React.FC<DistractionShieldProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/90 backdrop-blur-sm z-50 flex items-center justify-center relative">
+    <div className="fixed inset-0 bg-black/90 backdrop-blur-sm z-[110] flex items-center justify-center">
       <div className="text-center text-white space-y-4">
         <div className="text-8xl font-mono font-bold animate-pulse">
           {formatTime(timeLeft)}

--- a/src/components/DistractionShield.tsx
+++ b/src/components/DistractionShield.tsx
@@ -63,7 +63,7 @@ export const DistractionShield: React.FC<DistractionShieldProps> = ({
 
   return (
     <div className="fixed inset-0 bg-black/90 backdrop-blur-sm z-[110] flex items-center justify-center">
-      <div className="text-center text-white space-y-4">
+      <div className="text-center text-white space-y-4 flex flex-col items-center">
         <div className="text-8xl font-mono font-bold animate-pulse">
           {formatTime(timeLeft)}
         </div>
@@ -79,9 +79,9 @@ export const DistractionShield: React.FC<DistractionShieldProps> = ({
             (Shield blocks shortcuts and tab switching - works best in full browser)
           </p>
         </div>
-      </div>
-      <div className="absolute bottom-6 right-6 max-w-sm w-full">
-        <DistractionLog visible={!isBreak} />
+        <div className="max-w-sm w-full pt-6">
+          <DistractionLog visible={!isBreak} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/DistractionShield.tsx
+++ b/src/components/DistractionShield.tsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect } from 'react';
+import { DistractionLog } from './DistractionLog';
 
 interface DistractionShieldProps {
   timeLeft: number;
@@ -61,7 +62,7 @@ export const DistractionShield: React.FC<DistractionShieldProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/90 backdrop-blur-sm z-50 flex items-center justify-center">
+    <div className="fixed inset-0 bg-black/90 backdrop-blur-sm z-50 flex items-center justify-center relative">
       <div className="text-center text-white space-y-4">
         <div className="text-8xl font-mono font-bold animate-pulse">
           {formatTime(timeLeft)}
@@ -78,6 +79,9 @@ export const DistractionShield: React.FC<DistractionShieldProps> = ({
             (Shield blocks shortcuts and tab switching - works best in full browser)
           </p>
         </div>
+      </div>
+      <div className="absolute bottom-6 right-6 max-w-sm w-full">
+        <DistractionLog visible={!isBreak} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show DistractionLog component on the distraction shield

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ec3d4f9d48322b0b456787a9799d4