### PR TITLE
Enable service worker with live updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
     
     <!-- Canonical URL -->
     <link rel="canonical" href="https://smart-pomodoro.app/" />
+
+    <!-- PWA Manifest -->
+    <link rel="manifest" href="/manifest.json" />
     
     <!-- Favicon -->
     <link rel="icon" href="/logo.png" type="image/png" />
@@ -40,5 +43,24 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js').then(registration => {
+            registration.addEventListener('updatefound', () => {
+              const newWorker = registration.installing;
+              newWorker.addEventListener('statechange', () => {
+                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                  newWorker.postMessage({ type: 'SKIP_WAITING' });
+                }
+              });
+            });
+          });
+        });
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          window.location.reload();
+        });
+      }
+    </script>
   </body>
 </html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,6 +8,13 @@ self.addEventListener('install', event => {
   );
 });
 
+// Activate new service worker as soon as it's finished installing
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
 self.addEventListener('activate', event => {
   event.waitUntil(
     caches.keys().then(cacheNames =>


### PR DESCRIPTION
## Summary
- link PWA manifest in `index.html`
- register the service worker and force updates when new versions are installed
- handle SKIP_WAITING messages in `sw.js`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f2206dbc88322891ad0b5ab454fcb