### PR TITLE
Fix GitHub Pages routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
+  "homepage": "https://boqan.github.io/pomodoro-habit-tracker/",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/public/offline.html
+++ b/public/offline.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Smart Pomodoro - Offline</title>
   <meta name="description" content="You are offline, but Smart Pomodoro still works. Your tasks and habits are stored locally." />
-  <link rel="canonical" href="https://smart-pomodoro.app/offline.html" />
+  <link rel="canonical" href="https://bogan.github.io/pomodoro-habit-tracker/offline.html" />
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -49,7 +49,7 @@
   <div class="container">
     <h1>🍅 You're Offline</h1>
     <p>No internet connection, but you can still use your Pomodoro timer! Your tasks and habits are saved locally.</p>
-    <a href="/" class="button">Return to App</a>
+    <a href="/pomodoro-habit-tracker/" class="button">Return to App</a>
   </div>
 </body>
 </html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -13,4 +13,4 @@ Allow: /
 User-agent: *
 Allow: /
 
-Sitemap: https://smart-pomodoro.app/sitemap.xml
+Sitemap: https://bogan.github.io/pomodoro-habit-tracker/sitemap.xml

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ const App: React.FC = () => {
   return (
     <TooltipProvider>
       <HelmetProvider>
-        <BrowserRouter>
+        <BrowserRouter basename={import.meta.env.BASE_URL}>
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="*" element={<NotFound />} />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import { Helmet } from "react-helmet-async";
 
@@ -22,9 +22,9 @@ const NotFound = () => {
         <div className="text-center">
           <h1 className="text-4xl font-bold mb-4">404</h1>
           <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-          <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+          <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
             Return to Home
-          </a>
+          </Link>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- set the router's `basename` so React Router resolves paths correctly when hosted from `/pomodoro-habit-tracker/`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68500e4c55188322b1b23cee0c160780