### PR TITLE
Add toast notification hook for Pomodoro transitions

### DIFF
--- a/src/components/SmartPomodoro.tsx
+++ b/src/components/SmartPomodoro.tsx
@@ -20,6 +20,7 @@ import { XPTooltip } from './XPTooltip';
 import { DistractionLog } from './DistractionLog';
 import { Footer } from './Footer';
 import { DualTimer } from './DualTimer';
+import { notify } from '@/lib/notify';
 
 const SmartPomodoro = () => {
   const [focusLength, setFocusLength] = useState(25);
@@ -211,10 +212,12 @@ const SmartPomodoro = () => {
     if (isBreak) {
       if (currentCycle >= cycles) return sessionComplete();
       switchToFocus();
+      notify('Focus block started – break over');
     } else {
       if (currentCycle >= cycles) return sessionComplete();
       setCurrentCycle((c) => c + 1);
       switchToBreak();
+      notify('Focus block ended – break starting');
     }
 
     startTimer();

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,0 +1,19 @@
+export function notify(message: string) {
+  if (typeof window === 'undefined') return;
+
+  if ('Notification' in window) {
+    if (Notification.permission === 'granted') {
+      new Notification(message);
+    } else if (Notification.permission !== 'denied') {
+      Notification.requestPermission().then((permission) => {
+        if (permission === 'granted') {
+          new Notification(message);
+        }
+      });
+    }
+  }
+
+  if ('vibrate' in navigator) {
+    navigator.vibrate([200]);
+  }
+}


### PR DESCRIPTION
## Summary
- add `notify` helper for web notifications
- call `notify` when switching focus/break blocks

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68591635f6e88322ab0b962ba4565cdb