### PR TITLE
Add notify helper

### DIFF
--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,0 +1,22 @@
+import { toast } from "@/components/ui/sonner"
+
+/**
+ * Show a browser notification and toast.
+ *
+ * Should be called whenever a timer segment ends.
+ */
+export async function notify(title: string, body: string) {
+  if (typeof window !== "undefined" && "Notification" in window) {
+    if (Notification.permission === "default") {
+      try {
+        await Notification.requestPermission()
+      } catch {
+        /* ignore */
+      }
+    }
+    if (Notification.permission === "granted") {
+      new Notification(title, { body })
+    }
+  }
+  toast(body)
+}


### PR DESCRIPTION
## Summary
- add `notify` helper in `src/lib/notify.ts`
- document that it is used for timer segment end notifications

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68591634baf4832281379c070566dfc2